### PR TITLE
Fixed warning in src/peresec.c

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -126,7 +126,7 @@ pkg-before:
 pkg/%.tar.gz: pkg-before
 	-$(ECHO) 'Creating package: $<'
 	cd $(@D); \
-	$(TAR) --owner=0 --group=0 --exclude=*.tar.gz --exclude=*.zip -zcf "$(@F)" .
+	$(TAR) --exclude=*.tar.gz --exclude=*.zip -zcf "$(@F)" .
 	-$(ECHO) 'Finished creating: $<'
 	-$(ECHO) ' '
 

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ ifneq (,$(findstring Windows,$(OS)))
   PKGFMT = zip
   PKGOS = win
 else
-  RES  = 
+  RES  =
   EXEEXT =
   PKGFMT = tar.gz
   PKGOS = lin
@@ -49,16 +49,16 @@ $(RES)
 
 GENSRC   = obj/ver_defs.h
 LINKOBJ  = $(OBJS)
-LINKLIB = 
-INCS = 
-CXXINCS = 
+LINKLIB =
+INCS =
+CXXINCS =
 # flags to generate dependency files
-DEPFLAGS = -MMD -MP -MF"$(@:%.o=%.d)" -MT"$(@:%.o=%.d)" 
+DEPFLAGS = -MMD -MP -MF"$(@:%.o=%.d)" -MT"$(@:%.o=%.d)"
 # code optimization flags
 OPTFLAGS = -O3
 DBGFLAGS =
 # linker flags
-LINKFLAGS = 
+LINKFLAGS =
 # compiler warning generation flags
 WARNFLAGS = -Wall -Wno-sign-compare -Wno-unused-parameter
 # disabled warnings: -Wextra -Wtype-limits
@@ -102,7 +102,7 @@ obj/%.o: src/%.c $(GENSRC)
 
 obj/%.res: res/%.rc $(GENSRC)
 	-$(ECHO) 'Building resource: $<'
-	$(WINDRES) -i "$<" --input-format=rc -o "$@" -O coff 
+	$(WINDRES) -i "$<" --input-format=rc -o "$@" -O coff
 	-$(ECHO) 'Finished building: $<'
 	-$(ECHO) ' '
 

--- a/src/peresec.c
+++ b/src/peresec.c
@@ -1206,7 +1206,11 @@ short add_pe_section_header_to_buf(unsigned char **buf, long *filesize, struct s
     // Clear the new section
     memset(data, '\0', PE_SIZEOF_SECTHDR_ENTRY);
     // Write section name
-    strncpy((char *)data, new_sec->name, MAX_SECTION_NAME_LEN);
+    len = strlen(new_sec->name);
+    if (len >= MAX_SECTION_NAME_LEN) {
+        len = MAX_SECTION_NAME_LEN;
+    }
+    memcpy(data, new_sec->name, len);
     data += MAX_SECTION_NAME_LEN;
     // Write addresses and sizes
     write_int32_le_buf(data,new_sec->vsize); data += 4; // virtual size

--- a/src/peresec.c
+++ b/src/peresec.c
@@ -1162,6 +1162,8 @@ short add_pe_section_header_to_buf(unsigned char **buf, long *filesize, struct s
     unsigned long first_section_data_raddr;
     long insert_idx;
     long idx;
+    int len;
+
     // Get section headers position
     section_headers_raw_pos = pe->rvas_and_sizes_raddr + pe->rvas_and_sizes_num*PE_SIZEOF_DATADIR_ENTRY;
     // Initial value of the first section offset


### PR DESCRIPTION
Fixes warning:
```
In file included from /usr/include/string.h:535,
                 from src/peresec.c:22:
In function ‘strncpy’,
    inlined from ‘add_pe_section_header_to_buf’ at src/peresec.c:1209:5:
/usr/include/x86_64-linux-gnu/bits/string_fortified.h:95:10: warning: ‘__builtin_strncpy’ output may be truncated copying 8 bytes from a string of length 8 [-Wstringop-truncation]
   95 |   return __builtin___strncpy_chk (__dest, __src, __len,
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   96 |                                   __glibc_objsize (__dest));
      |                                   ~~~~~~~~~~
```